### PR TITLE
mxTryHard adjustments:

### DIFF
--- a/R/MxRun.R
+++ b/R/MxRun.R
@@ -331,14 +331,14 @@ mxTryHard<-function (model, extraTries = 10, greenOK = FALSE, loc = 1,
         message('\nSolution found\n')
         fit<-bestfit
         if(length(fit$intervals)>0){ #only calculate confidence intervals once the best fit is established
-          fit<-omxSetParameters(fit, names(bestfit.params),params)
-          message("Refit using best inits and estimate confidence intervals") 
+          fit<-omxSetParameters(fit, labels=names(bestfit.params),values=bestfit.params)
+          message("Refit using best inits and estimate confidence intervals\n") 
           #           mxOption(NULL, "Default optimizer", "NPSOL")
           cifit<-suppressWarnings(try(mxRun(fit,intervals=TRUE,suppressWarnings=T,silent=T)))
           if(class(cifit) == "try-error" || cifit$output$status$status== -1) {
-            message('Confidence interval estimation generated errors')
+            message('Confidence interval estimation generated errors\n')
           } else {
-            if (length(summary(cifit)$npsolMessage) > 0) message('Warning messages generated from confidence interval refit')
+            if (length(summary(cifit)$npsolMessage) > 0) message('Warning messages generated from confidence interval refit\n')
             fit<-cifit
           }
           
@@ -363,12 +363,12 @@ mxTryHard<-function (model, extraTries = 10, greenOK = FALSE, loc = 1,
         fit <- bestfit
         params <- bestfit.params
         if(length(fit$intervals)>0){ #calculate intervals for best fit, even though imperfect
-          fit<-omxSetParameters(fit, names(bestfit.params),params)
-          message("Refit using best inits and estimate confidence intervals") 
+          fit<-omxSetParameters(fit, labels=names(bestfit.params),values=bestfit.params)
+          message("Refit using best inits and estimate confidence intervals\n") 
           #           mxOption(NULL, "Default optimizer", "NPSOL")
           cifit<-suppressWarnings(try(mxRun(fit,intervals=TRUE,suppressWarnings=T,silent=T)))
           if(class(cifit) == "try-error" || cifit$output$status$status== -1) {
-            message('Confidence interval estimation generated errors, returning fit without confidence intervals')
+            message('Confidence interval estimation generated errors, returning fit without confidence intervals\n')
           } else {
             fit<-cifit
           }

--- a/R/MxRun.R
+++ b/R/MxRun.R
@@ -249,47 +249,152 @@ updateModelExpectationDims <- function(model, expectations){
 #   *Stop further tries if fit function value is getting worse, or is improving by less than some amount (Mike Neale's
 #     deltas).
 
-mxTryHard <- function(model,extraTries=10,greenOK=FALSE,loc=1,scale=0.25,checkHess=TRUE,fit2beat=Inf,paste=TRUE,...){
-  stopflag <- FALSE#; stopBecauseMaxTries <- FALSE
+mxTryHard<-function (model, extraTries = 10, greenOK = FALSE, loc = 1, 
+  scale = 0.25, checkHess = TRUE, fit2beat = Inf, paste = TRUE,
+  iterationSummary=FALSE, bestInitsOutput=TRUE, showInits=FALSE,
+  ...) 
+{
+  
+  stopflag <- FALSE
   numdone <- 0
-  while(!stopflag){
+  bestfitsofar<-Inf
+  inits<-omxGetParameters(model)
+  while (!stopflag) {
+    if(iterationSummary==TRUE) message(paste0('\nBegin fit attempt ', numdone+1, ' of at maximum ', extraTries +1, ' tries'))
     params <- omxGetParameters(model)
-    numdone <- numdone+1
-    fit <- try(mxRun(model,suppressWarnings=T,...))
-    if(class(fit)=="try-error" || fit$output$status$status == -1 ){ #<--Check for -1 status suggested by Charlie Driver
-      model <- omxSetParameters(model,labels=names(params),values=params*runif(length(params),loc-scale,loc+scale))
+    if(showInits==TRUE) {
+      message('Starting values:  ')
+      message(paste0(names(params),' : ', params,'\n'))
     }
-    else{
-      objval <- fit$output$minimum
-      #Store the best fit found during attempts that beats fit2beat:
-      if(objval<=fit2beat){bestfit <- fit; bestfit.params <- params}
-      if(length(fit$output$calculatedHessian)==0){checkHess <- FALSE}
-      if(checkHess){if(sum(is.na(fit$output$calculatedHessian))>0){checkHess <- FALSE}}
-      stopflag <- ifelse(checkHess,(fit$output$status[[1]]<=greenOK) & 
-                           (all(eigen(fit$output$calculatedHessian,symmetric=T,only.values=T)$values>0)) & (objval<=fit2beat),
-                         (fit$output$status[[1]]<=greenOK) & (objval<=fit2beat))
-      if(!stopflag){
+    numdone <- numdone + 1
+    
+    fit <- suppressWarnings(try(mxRun(model, suppressWarnings = T, unsafe=T, silent=T,intervals=FALSE)))
+    if (class(fit) == "try-error" || fit$output$status$status== -1) {
+      newparams<-omxGetParameters(model) #get recent fit
+      if(exists('bestfit')) newparams<-bestfit.params #if bestfit exists use this instead
+      if(numdone %% 4 == 0) newparams<-inits #sometimes, use initial start values instead
+      #       if(numdone %% 5 == 0) { #sometimes, switch optimizers
+      #         if(mxOption(NULL, "Default optimizer")=='CSOLNP') newoptimizer<-'NPSOL'
+      #         if(mxOption(NULL, "Default optimizer")=='NPSOL') newoptimizer<-'CSOLNP'
+      #         message(paste0('Switching to ',newoptimizer,' optimizer for OpenMx temporarily')) 
+      #         mxOption(NULL, "Default optimizer", newoptimizer)
+      #       }
+      model <- omxSetParameters(model, labels = names(newparams), 
+        values = newparams * runif(length(params),loc-scale,loc+scale))  #set to multiply bestfit.params instead of params
+    }
+    else { #if fit was not an error
+      if (fit$output$minimum <= bestfitsofar) {
+        bestfit <- fit
+        bestfit.params <- omxGetParameters(bestfit)
+      }
+      
+      if(fit$output$minimum < bestfitsofar) bestfitsofar <- fit$output$minimum
+      
+      if (length(fit$output$calculatedHessian) == 0) {
+        checkHess <- FALSE
+      }
+      if (checkHess) {
+        if (sum(is.na(fit$output$calculatedHessian)) > 
+            0) {
+          checkHess <- FALSE
+        }
+      }
+      
+      stopflag <- ifelse(checkHess, (fit$output$status[[1]] <= 
+          greenOK) & (all(eigen(fit$output$calculatedHessian, 
+            symmetric = T, only.values = T)$values > 0)) & 
+          (fit$output$minimum <= fit2beat) & (fit$output$minimum <= bestfitsofar), (fit$output$status[[1]] <=  #added bestfitsofar condition
+              greenOK) & (fit$output$minimum <= fit2beat) & (fit$output$minimum <= bestfitsofar) )
+      if (!stopflag) {
         model <- fit
-        model <- omxSetParameters(model,labels=names(params),
-                                  values=fit$output$estimate*runif(length(params),loc-scale,loc+scale))
-        fit2beat <- ifelse(objval<fit2beat,objval,fit2beat)
+        newparams<-omxGetParameters(fit) #get recent fit
+        if(exists('bestfit')) newparams<-bestfit.params #if bestfit exists use this instead
+        if(numdone %% 4 == 0) newparams<-inits #sometimes, use initial start values instead
+        #         if(numdone %% 5 == 0) { #sometimes, switch optimizers
+        #           if(mxOption(NULL, "Default optimizer")=='CSOLNP') newoptimizer<-'NPSOL'
+        #           if(mxOption(NULL, "Default optimizer")=='NPSOL') newoptimizer<-'CSOLNP'
+        #           message(paste0('Switching to ',newoptimizer,' optimizer for OpenMx temporarily')) 
+        #           mxOption(NULL, "Default optimizer", newoptimizer)
+        #         }
+        model <- omxSetParameters(model, labels = names(params), 
+          values = newparams * runif(length(params),loc-scale,loc+scale))
+        fit2beat <- ifelse(fit$output$minimum < fit2beat, fit$output$minimum, 
+          fit2beat)
+        if(iterationSummary==TRUE){
+          message(paste0("Attempt ",numdone," fit:  "))
+          message(paste(names(params),": ", fit$output$estimate,"\n"))
+          message(paste0("-2LL = ", fit$output$Minus2LogLikelihood))
+        }
+      }
+      
+      if(stopflag){
+        message('\nSolution found\n')
+        fit<-bestfit
+        if(length(fit$intervals)>0){ #only calculate confidence intervals once the best fit is established
+          fit<-omxSetParameters(fit, names(bestfit.params),params)
+          message("Refit using best inits and estimate confidence intervals") 
+          #           mxOption(NULL, "Default optimizer", "NPSOL")
+          cifit<-suppressWarnings(try(mxRun(fit,intervals=TRUE,suppressWarnings=T,silent=T)))
+          if(class(cifit) == "try-error" || cifit$output$status$status== -1) {
+            message('Confidence interval estimation generated errors')
+          } else {
+            if (length(summary(cifit)$npsolMessage) > 0) message('Warning messages generated from confidence interval refit')
+            fit<-cifit
+          }
+          
+        }
+        if (length(summary(fit)$npsolMessage) > 0) {
+          warning(summary(fit)$npsolMessage)
+        }
+        
+        params <- bestfit.params
+        
+        if(iterationSummary==TRUE){
+          message(paste(names(bestfit.params),": ", bestfit$output$estimate,"\n"))
+          message(paste0("-2LL = ", bestfit$output$Minus2LogLikelihood))
+        }
+        
+      }
+    } #end 'if fit not an error' section
+    if (numdone > extraTries & stopflag==FALSE) { #added stopflag==FALSE
+      message('\nRetry limit reached')
+      stopflag <- TRUE
+      if (exists("bestfit")) {
+        fit <- bestfit
+        params <- bestfit.params
+        if(length(fit$intervals)>0){ #calculate intervals for best fit, even though imperfect
+          fit<-omxSetParameters(fit, names(bestfit.params),params)
+          message("Refit using best inits and estimate confidence intervals") 
+          #           mxOption(NULL, "Default optimizer", "NPSOL")
+          cifit<-suppressWarnings(try(mxRun(fit,intervals=TRUE,suppressWarnings=T,silent=T)))
+          if(class(cifit) == "try-error" || cifit$output$status$status== -1) {
+            message('Confidence interval estimation generated errors, returning fit without confidence intervals')
+          } else {
+            fit<-cifit
+          }
+        }
+        if (length(fit$output$status$statusMsg) > 0) { 
+          warning(fit$output$status$statusMsg)
+        }
+        if(fit$output$status$code==6) message('\nUncertain solution found - consider parameter validity, try again, increase extraTries, change inits, change model, or check data!\n')
+        if(iterationSummary==TRUE){
+          message(paste(names(bestfit.params),": ", bestfit$output$estimate,"\n"))
+          message(paste0("-2LL = ", bestfit$output$Minus2LogLikelihood))
+        }
+      }
+      if (!exists("bestfit")) {
+        if (length(fit$output$status$statusMsg) > 0) { 
+          warning(fit$output$status$statusMsg)
+        }
       }
     }
-    if(numdone>extraTries){
-      #stopBecauseMaxTries <- ifelse(stopflag,FALSE,TRUE)
-      stopflag <- TRUE
-  }}
-  if(class(fit)!="try-error" & fit$output$status$status > -1){
-    #If bestfit exists and has smaller objective function value than most recent fit, use bestfit instead:
-    if(exists("bestfit")){if(bestfit$output$minimum<fit$output$minimum){fit <- bestfit; params <- bestfit.params}}
-    if(length(summary(fit)$npsolMessage)>0){warning(summary(fit)$npsolMessage)}
   }
-  #If most recent try ended in error or optimization failed, and bestfit exists, then of course use bestfit:
-  else{if(exists("bestfit")){
-    fit <- bestfit; params <- bestfit.params
-    if(length(summary(fit)$npsolMessage)>0){warning(summary(fit)$npsolMessage)}
-  }}
-  print(ifelse(paste,paste(params,collapse=","),params))
+  if(bestInitsOutput){
+    message("\nStart values from best fit:")
+    if(paste) message(paste(params, sep=",", collapse = ",")) 
+    if(!paste)  message(paste(names(params),": ", params,"\n"))
+  }
   return(fit)
 }
+
   

--- a/man/mxTryHard.Rd
+++ b/man/mxTryHard.Rd
@@ -19,6 +19,9 @@ mxTryHard(model,extraTries=10,greenOK=FALSE,loc=1,scale=0.25,checkHess=TRUE,fit2
   \item{checkHess}{Logical; is a positive-definite Hessian a requirement for an acceptable solution?  Defaults to \code{TRUE}.}
   \item{fit2beat}{An upper limit to the objective-function value that an acceptable solution may have.  Useful if a nested submodel of \code{model} has already been fitted, since \code{model}, with its additional free parameters, should not yield a fit-function value any greater than that of the submodel.}
   \item{paste}{Logical.  If \code{TRUE} (default), start values for the returned fitted model are printed to console as a comma-separated string.  This is useful if the user wants to copy-paste these values into an \R script, say, in an \code{\link{omxSetParameters}()} statement. If \code{FALSE}, the vector of start values is printed as-is.  Note that this vector, from \code{\link{omxGetParameters}()}, has names corresponding to the free parameters; these names are not displayed when \code{paste=TRUE}.}
+  \item{iterationSummary}{Logical. If \code{TRUE}, displays parameter estimates and fit values for every fit attempt. Defaults to \code{FALSE}.}
+  \item{bestInitsOutput}{Logical. If \code{TRUE}, outputs starting values that resulted in best fit, according to format specified by \code{paste} argument. Defaults to \code{TRUE}.}
+  \item{showInits}{Logical. If \code{TRUE}, displays starting values for every fit attempt. Defaults to \code{FALSE}.}
   \item{...}{Additional arguments to be passed to \code{\link{mxRun}()} (for example, \code{intervals=TRUE}).  Note that \code{mxTryHard()} always internally invokes \code{\link{mxRun}()} with argument \code{suppressWarnings=TRUE}.}
 }
 


### PR DESCRIPTION
Revert to initial starting values every 4th iteration
Only calculate confidence intervals after adequate solution is found or retry limit is reached
Option for parameter and fit summary at every iteration
Option for displaying init values at every iteration
Option to disable best init output
Added ‘bestfitsofar’ condition for acceptance because code 6’s sometimes had better fits than code 0’s but the code 0’s would be accepted.
Suppress warnings on iterations
Explain code red in pragmatic language
Use message() rather than paste() for output
updated documentation