### PR TITLE
fix due to Eigen plugin

### DIFF
--- a/src/omxDefines.h
+++ b/src/omxDefines.h
@@ -241,6 +241,7 @@ static inline int omp_get_thread_num() { return 0; }
 static inline int omp_get_num_threads(void) { return 1; }
 #endif
 
+#include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <Eigen/Core>
 
 // Refactor as a single split function that pulls out all 3 parts

--- a/src/omxMLFitFunction.cpp
+++ b/src/omxMLFitFunction.cpp
@@ -14,6 +14,7 @@
  *  limitations under the License.
  */
 
+#include <stan/math/prim/mat/fun/Eigen.hpp>
 #include "omxDefines.h"
 
 #include <utility>

--- a/src/omxMLFitFunction.cpp
+++ b/src/omxMLFitFunction.cpp
@@ -18,7 +18,6 @@
 #include "omxDefines.h"
 
 #include <utility>
-#include <stan/math/prim/mat/fun/Eigen.hpp>
 #include <stan/math/mix/mat.hpp>
 #include "multi_normal_sufficient.hpp"
 

--- a/src/omxMLFitFunction.cpp
+++ b/src/omxMLFitFunction.cpp
@@ -14,7 +14,6 @@
  *  limitations under the License.
  */
 
-#include <stan/math/prim/mat/fun/Eigen.hpp>
 #include "omxDefines.h"
 
 #include <utility>


### PR DESCRIPTION
The OpenMx R package will fail with the next version of StanHeaders due to a useful but somewhat incompatible change introduced in Stan Math 2.20 that uses the Eigen plugin mechanism to hold adjoints along with the double values in `Eigen::Matrix<T, -1, -1>`. According to the Eigen [documentation](http://eigen.tuxfamily.org/dox/TopicCustomizing_Plugins.html) such plugins have to be `#include`d before any other Eigen headers. The OpenMx R package `#include`s "omxDefines.h" first, which includes Eigen/Core which then leads to compilation errors.

The fix in this is PR is trivial and installs when I put the necessary line into the OpenMx 2.14.x source that I downloaded from CRAN. But the git master branch seems to fail to install for unrelated reasons. If you need to test with the soon-to-be CRAN StanHeaders, you can do
```
source("https://raw.githubusercontent.com/stan-dev/rstan/for_2.20/StanHeaders/install-github.R")
install_StanHeaders(math_branch = "StanHeaders_2.21",
                    library_branch = "StanHeaders_2.21")
```
Please include this fix in an upload of OpenMx to CRAN as soon as you can. For reasons that are unrelated to OpenMx, we need to do a StanHeaders and a rstan release to overcome the fact that almost no Stan programs work on the Catalina version of the Mac operating system.