### PR TITLE
Support Stan v2.26+ / Math v4.0+

### DIFF
--- a/src/multi_normal_sufficient.hpp
+++ b/src/multi_normal_sufficient.hpp
@@ -3,6 +3,21 @@
 
 #include <boost/random/normal_distribution.hpp>
 #include <boost/random/variate_generator.hpp>
+
+#include <stan/math/version.hpp>
+#if STAN_MATH_MAJOR >= 4
+#include <stan/math/prim/err/check_ldlt_factor.hpp>
+#include <stan/math/prim/err/check_symmetric.hpp>
+#include <stan/math/prim/err/check_size_match.hpp>
+#include <stan/math/prim/err/check_finite.hpp>
+#include <stan/math/prim/err/check_not_nan.hpp>
+#include <stan/math/prim/err/check_positive.hpp>
+#include <stan/math/prim/fun/trace_inv_quad_form_ldlt.hpp>
+#include <stan/math/prim/fun/log_determinant_ldlt.hpp>
+#include <stan/math/prim/fun/max_size_mvt.hpp>
+#include <stan/math/prim/meta/return_type.hpp>
+#include <stan/math/prim/meta/include_summand.hpp>
+#else
 #include <stan/math/prim/mat/err/check_ldlt_factor.hpp>
 #include <stan/math/prim/mat/err/check_symmetric.hpp>
 #include <stan/math/prim/scal/err/check_size_match.hpp>
@@ -14,6 +29,7 @@
 #include <stan/math/prim/scal/meta/return_type.hpp>
 #include <stan/math/prim/scal/meta/max_size_mvt.hpp>
 #include <stan/math/prim/scal/meta/include_summand.hpp>
+#endif
 
 namespace stan {
 
@@ -59,7 +75,11 @@ namespace stan {
                        "Size of data covariance", sampleSigma.rows(), 
                        "size of model covariance", Sigma.rows());
   
+#if STAN_MATH_MAJOR >= 4
+      auto ldlt_Sigma = stan::math::make_ldlt_factor(Sigma);
+#else
       stan::math::LDLT_factor<param_t,Eigen::Dynamic,Eigen::Dynamic> ldlt_Sigma(Sigma);
+#endif
       check_ldlt_factor(function, "LDLT_Factor of covariance parameter", ldlt_Sigma);
 
       Eigen::Matrix<param_t, Eigen::Dynamic, Eigen::Dynamic> ss;

--- a/src/omxDefines.h
+++ b/src/omxDefines.h
@@ -230,7 +230,12 @@ static inline int omp_get_thread_num() { return 0; }
 static inline int omp_get_num_threads(void) { return 1; }
 #endif
 
+#include <stan/math/version.hpp>
+#if STAN_MATH_MAJOR >= 4
+#include <stan/math/prim/fun/Eigen.hpp>
+#else
 #include <stan/math/prim/mat/fun/Eigen.hpp>
+#endif
 #include <Eigen/Core>
 
 // Refactor as a single split function that pulls out all 3 parts

--- a/src/omxMLFitFunction.cpp
+++ b/src/omxMLFitFunction.cpp
@@ -17,7 +17,11 @@
 #include "omxDefines.h"
 
 #include <utility>
+#if STAN_MATH_MAJOR >= 4
+#include <stan/math/mix.hpp>
+#else
 #include <stan/math/mix/mat.hpp>
+#endif
 #include "multi_normal_sufficient.hpp"
 
 #include "omxExpectation.h"
@@ -453,11 +457,15 @@ void MLFitState::init()
 	}
 
 	EigenMatrixAdaptor obCov(newObj->observedCov);
+#if STAN_MATH_MAJOR >= 4
+	auto ldlt_obCov = stan::math::make_ldlt_factor(obCov);
+#else
 	stan::math::LDLT_factor<double,Eigen::Dynamic,Eigen::Dynamic> ldlt_obCov(obCov);
 	if (!ldlt_obCov.success()) {
 		omxRaiseErrorf("Observed Covariance Matrix is non-positive-definite.");
 		return;
 	}
+#endif
 	newObj->logDetObserved = log_determinant_ldlt(ldlt_obCov);
 	if(OMX_DEBUG) { mxLog("Log Determinant of Observed Cov: %f", newObj->logDetObserved); }
 }


### PR DESCRIPTION
The new version of `StanHeaders` (https://github.com/stan-dev/rstan/pull/887 and https://github.com/stan-dev/rstan/pull/912) will include breaking changes such as the new API for `LDT_factor`; see https://github.com/stan-dev/rstan/issues/899#issuecomment-788273482. This PR makes the required changes for the current release of Stan/Math while maintaining backward compatibility.