### PR TITLE
fix compile error on windows: 'cannot call member function without object'

### DIFF
--- a/src/omxState.cpp
+++ b/src/omxState.cpp
@@ -1226,7 +1226,7 @@ void ConstraintVec::eval(FitContext *fc, double *constrOut, double *jacOut)
                 // update only that parameter instead of all
                 // of them.
                 fc2->setEstFromOptimizer(Est);
-                eval(fc2, result.data(), 0);
+                this->eval(fc2, result.data(), 0);
               }, constr, [&fc](){ return fc->getCurrentFree(); }, true, constrJac);
 
     if (verifyJac) {


### PR DESCRIPTION
For some reason, this explicit reference to this-> needed to be added to build on windows in the conda-forge CI build environment (https://github.com/conda-forge/r-openmx-feedstock).

For now I have it as a patch in the feedstock, but thought I'd float it upstream to see what y'all think.