### PR TITLE
Prevent data.frame from dropping to class vector

### DIFF
--- a/R/MxAutoStart.R
+++ b/R/MxAutoStart.R
@@ -138,7 +138,7 @@ autoStartDataHelper <- function(model, subname=model@name, type){
 			mdata$observedStats$means <- meanData
 		}
 	} else if (origDataType == 'raw') {
-		data <- data[,useVars]
+		data <- data[,useVars, drop = FALSE]
 		# This conditional is for cases when the model has only 1 endogenous variable:
 		if(!is.matrix(data) && !is.data.frame(data)){
 			data <- as.matrix(data)


### PR DESCRIPTION
If the model has only 1 endogenous variable, the data drop to class == "vector" when subsetting with `data <- data[,useVars]`. Subsequently, the code `data <- as.matrix(data)` returns the data to tabular format - but loses the original class of the endogenous variable in the process. For example, if we start with a single variable of class "ordered", we will end up with a single variable of class "character". This is undesirable. By using the argument `, drop = FALSE` when subsetting, this problem is avoided entirely.