### PR TITLE
Add some static_cast<int> to permit Eigen 3.4.0 compilation

### DIFF
--- a/src/omxData.cpp
+++ b/src/omxData.cpp
@@ -1632,7 +1632,7 @@ void omxData::wlsAllContinuousCumulants(omxState *state)
 			ind.segment(2,2) = M.row(jx);
 			Umat(ix,jx) = (data.col(ind[0]) * data.col(ind[1]) *
 				       data.col(ind[2]) * data.col(ind[3]) * rowMult).sum() / totalWeight -
-				Vmat(ind[0],ind[1]) * Vmat(ind[2],ind[3]);
+			  Vmat(static_cast<int>(ind[0]),static_cast<int>(ind[1])) * Vmat(static_cast<int>(ind[2]),static_cast<int>(ind[3]));
 		}
 	}
   Umat.triangularView<Eigen::Upper>() = Umat.transpose().triangularView<Eigen::Upper>();
@@ -1667,7 +1667,7 @@ void omxData::wlsAllContinuousCumulants(omxState *state)
 			for (int ix=0; ix < numColsStar; ++ix) {
 				uw(ix,ix) = totalWeight/((data.col(M(ix, 0)) * data.col(M(ix, 0)) *
 						  data.col(M(ix, 1)) * data.col(M(ix, 1))).sum() / totalWeight -
-						  Vmat(M(ix, 0), M(ix, 1)) * Vmat(M(ix, 0), M(ix, 1)));
+							 Vmat(static_cast<int>(M(ix, 0)), static_cast<int>(M(ix, 1))) * Vmat(static_cast<int>(M(ix, 0)), static_cast<int>(M(ix, 1))));
 			}
 			uw.derived() = (p1.transpose() * uw * p1).eval();
 		}
@@ -2193,9 +2193,9 @@ struct PolyserialCor : NewtonRaphsonObjective {
 				1.0/(2*var) * ((zee[rx]*zee[rx] - 1.0) +
 					       rho*zee[rx] * irpr * (dzi(rx,0)-dzi(rx,1)));
 			if (ycol(rx) < numThr)
-				scores(rx, 2 + ycol(rx)) = dzi(rx,0) * irpr;
+  			        scores(rx, 2 + static_cast<int>(ycol(rx))) = dzi(rx,0) * irpr;
 			if (ycol(rx)-1 >= 0)
-				scores(rx, 2 + ycol(rx)-1) = -dzi(rx,1) * irpr;
+				scores(rx, 2 + static_cast<int>(ycol(rx))-1) = -dzi(rx,1) * irpr;
 			for (int px=0; px < int(pred1.size()); ++px) {
 				scores(rx, 2+numThr+px) = scores(rx,0) * pred1[px][rx];
 			}


### PR DESCRIPTION
Dear Joshua, dear OpenMx team,

Eigen 3.4.0 was released earlier in the year, and I have been asked to update RcppEigen to it. As documented [in this issue at its GitHub repo](https://github.com/RcppCore/RcppEigen/issues/103), there are about nine packages that built at CRAN under the previous release, but not with the Eigen 3.4.0 changes in the release candidate package -- which can be installed via

    install.packages("RcppEigen", repo="https://RcppCore.github.io/drat")

For OpenMx, the change is (mostly) fairly simple. Apparently Eigen 3.4.0 gets confused by other Eigen objects used as matrix indices so a few `static_cast<int>()` help. With that simple changes in this PR, the package (almost) installs for me. One remaining change is on line 352 of povRAM.cpp where the compiler takes issue with `symSolver.compute(sio->full);`  and I have no idea why. If you could look into this I would greatly appreciate it!  The RcppEigen pre-release from the drat repo listed above will let you test this.

It would be helpful for RcppEigen if you could apply the patch (and extend it to the remaining issue) and release an updated version so that RcppEigen could be upgraded to a version with Eigen 3.4.0.

Let me know if you have any question, and please do not hesitate to reply and ask.

Cheers, Dirk (who looks after RcppEigen as a care-taker...)