### PR TITLE
Fix CRAN notes for C++ standard and parallelism in examples

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,7 +44,7 @@ Description: Create structural equation models that can be manipulated programma
 	Support and advanced package binaries available at <http://openmx.ssri.psu.edu>.
     The software is described in Neale, Hunter, Pritikin, Zahery, Brick,
     Kirkpatrick, Estabrook, Bates, Maes, & Boker (2016) <doi:10.1007/s11336-014-9435-8>.
-SystemRequirements: GNU make, C++14
+SystemRequirements: GNU make, C++17
 ByteCompile: no
 Language: en-US
 License: Apache License (== 2.0)

--- a/DESCRIPTION.in
+++ b/DESCRIPTION.in
@@ -44,7 +44,7 @@ Description: Create structural equation models that can be manipulated programma
 	Support and advanced package binaries available at <http://openmx.ssri.psu.edu>.
     The software is described in Neale, Hunter, Pritikin, Zahery, Brick,
     Kirkpatrick, Estabrook, Bates, Maes, & Boker (2016) <doi:10.1007/s11336-014-9435-8>.
-SystemRequirements: GNU make, C++14
+SystemRequirements: GNU make, C++17
 ByteCompile: @BC@
 Language: en-US
 License: @LICENSE@

--- a/man/mxExpectationStateSpace.Rd
+++ b/man/mxExpectationStateSpace.Rd
@@ -136,6 +136,10 @@ The OpenMx User's guide can be found at \url{https://openmx.ssri.psu.edu/documen
 }
 
 % donttest as gives NOTE Examples with CPU time > 2.5 times elapsed time
+
+
+\examples{
+
 \donttest{
 # Create and fit a model using mxMatrix, mxExpectationStateSpace, and mxFitFunctionML
 require(OpenMx)
@@ -190,5 +194,7 @@ summary(ssRun)
 #  are both near zero as they should be for the independent rows of data
 #  from the factor model that does not have inputs, covariates,
 #  or exogenous variables.
+
+}
 
 }

--- a/man/mxExpectationStateSpace.Rd
+++ b/man/mxExpectationStateSpace.Rd
@@ -4,9 +4,9 @@
 %   Licensed under the Apache License, Version 2.0 (the "License");
 %   you may not use this file except in compliance with the License.
 %   You may obtain a copy of the License at
-% 
+%
 %        http://www.apache.org/licenses/LICENSE-2.0
-% 
+%
 %   Unless required by applicable law or agreed to in writing, software
 %   distributed under the License is distributed on an "AS IS" BASIS,
 %   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -60,7 +60,7 @@ The hybrid Kalman filter (combination of classical Kalman and Kalman-Bucy filter
 
 Missing data handling is implemented in the same fashion as full information maximum likelihood for partially missing rows of data.  Additionally, completely missing rows of data are handled by only using the prediction step from the Kalman filter and omitting the update step.
 
-This model uses notation for the model matrices commonly found in engineering and control theory.  
+This model uses notation for the model matrices commonly found in engineering and control theory.
 
  The 'A', 'B', 'C', 'D', 'Q', 'R', 'x0', and 'P0' arguments must be the names of \link{MxMatrix} or \link{MxAlgebra}objects with the associated properties of the A, B, C, D, Q, R, x0, and P0 matrices in the state space modeling approach.
 
@@ -89,7 +89,7 @@ The 'dimnames' arguments takes an optional character vector.  % TODO: Decide how
 
 The 'A' argument refers to the \eqn{A} matrix in the State Space approach. This matrix consists of time regressive coefficients from the latent variable in column \eqn{j} at time \eqn{t-1} to the latent variable in row \eqn{i} at time \eqn{t}.  Entries in the diagonal are autoregressive coefficients.  Entries in the off-diagonal are cross-lagged regressive coefficients.  If the \eqn{A} and \eqn{B} matrices are zero matrices, then the state space model reduces to a factor analysis.  The \eqn{A} matrix is sometimes called the state-transition model.
 
-The 'B' argument refers to the \eqn{B} matrix in the State Space approach. This matrix consists of regressive coefficients from the input (manifest covariate) variable \eqn{j} at time \eqn{t} to the latent variable in row \eqn{i} at time \eqn{t}.  Note that the covariate effect is contemporaneous: the covariate at time \eqn{t} has influence on the latent state also at time \eqn{t}.  A lagged effect can be created by lagged the observed variable.  The \eqn{B} matrix is sometimes called the control-input model. 
+The 'B' argument refers to the \eqn{B} matrix in the State Space approach. This matrix consists of regressive coefficients from the input (manifest covariate) variable \eqn{j} at time \eqn{t} to the latent variable in row \eqn{i} at time \eqn{t}.  Note that the covariate effect is contemporaneous: the covariate at time \eqn{t} has influence on the latent state also at time \eqn{t}.  A lagged effect can be created by lagged the observed variable.  The \eqn{B} matrix is sometimes called the control-input model.
 
 The 'C' argument refers to the \eqn{C} matrix in the State Space approach. This matrix consists of contemporaneous regression coefficients from the latent variable in column \eqn{j} to the observed variable in row \eqn{i}.  This matrix is directly analogous to the factor loadings matrix in LISREL and Mplus models.  The \eqn{C} matrix is sometimes called the observation model.
 
@@ -135,8 +135,8 @@ G. Petris  (2010).  An R Package for Dynamic Linear Models.  \emph{Journal of St
 The OpenMx User's guide can be found at \url{https://openmx.ssri.psu.edu/documentation/}.
 }
 
-\examples{
-   
+% donttest as gives NOTE Examples with CPU time > 2.5 times elapsed time
+\donttest{
 # Create and fit a model using mxMatrix, mxExpectationStateSpace, and mxFitFunctionML
 require(OpenMx)
 data(demoOneFactor)

--- a/man/mxParametricBootstrap.Rd
+++ b/man/mxParametricBootstrap.Rd
@@ -55,6 +55,9 @@ Details of the bootstrap replications are stored in the
 }
 
 % donttest as gives NOTE Examples with CPU time > 2.5 times elapsed time
+
+\examples{
+
 \donttest{
 library(OpenMx)
 
@@ -77,4 +80,6 @@ base <- mxRun(base)
 # use more replications, 8 is for demonstration purpose only
 mxParametricBootstrap(base, paste0('l', 1:length(manifests)),
                       "two.sided", replications=8)
+}
+
 }

--- a/man/mxParametricBootstrap.Rd
+++ b/man/mxParametricBootstrap.Rd
@@ -54,7 +54,8 @@ Details of the bootstrap replications are stored in the
 \sQuote{bootData} attribute on the data frame.
 }
 
-\examples{
+% donttest as gives NOTE Examples with CPU time > 2.5 times elapsed time
+\donttest{
 library(OpenMx)
 
 data(demoOneFactor)

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -6,7 +6,7 @@
 #
 # Now edit to Makeconf to adjust the default compiler flags.
 
-CXX_STD = CXX14
+CXX_STD = CXX17
 
 NO_INLINE=-fno-inline -fno-inline-small-functions -fno-default-inline
 

--- a/src/Makevars.win.in
+++ b/src/Makevars.win.in
@@ -1,4 +1,4 @@
-CXX_STD = CXX14
+CXX_STD = CXX17
 
 # Developer's Note: As of R 3.5.3 and Rtools35.exe you must set the following flags
 #  CXX14 = $(BINPREF)g++ $(M_ARCH)


### PR DESCRIPTION
This PR resolves the NOTEs from the [automated checks of your last submission](https://win-builder.r-project.org/incoming_pretest/OpenMx_2.21.6_20230403_191257/): 
```
* checking C++ specification ... NOTE
  Specified C++14: please drop specification unless essential
...
* checking examples ... [60s/38s] NOTE
Examples with CPU time > 2.5 times elapsed time
                         user system elapsed ratio
mxExpectationStateSpace 1.072  0.012   0.361 3.003
mxParametricBootstrap   1.798  0.056   0.639 2.901
```

I've bumped the c++ standard to c++17, and wrapped the above examples in `\donttest{}` so that they're skipped during the automated checks (but run during the extended checks).