### PR TITLE
Prepare for RcppEigen header reorganization

### DIFF
--- a/DESCRIPTION.in
+++ b/DESCRIPTION.in
@@ -48,7 +48,7 @@ SystemRequirements: GNU make, C++17
 ByteCompile: @BC@
 Language: en-US
 License: @LICENSE@
-LinkingTo: Rcpp, RcppEigen, RcppParallel, StanHeaders (>= 2.10.0.2), BH (>= 1.69.0-1), rpf (>= 0.45)
+LinkingTo: Rcpp, RcppEigen (>= 0.3.3.9.3.2), RcppParallel, StanHeaders (>= 2.10.0.2), BH (>= 1.69.0-1), rpf (>= 0.45), Matrix
 Imports: digest,
     MASS,
     Matrix (>= 1.2-16),

--- a/src/Compute.cpp
+++ b/src/Compute.cpp
@@ -32,14 +32,16 @@
 #include "omxData.h"
 #include <Eigen/Cholesky>
 #include <Eigen/QR>
-#include <Eigen/CholmodSupport>
 #include <Eigen/Dense>
+#include <RcppEigenCholmod.h>
 #include <RcppEigenWrap.h>
 #include "finiteDifferences.h"
 #include "autoTune.h"
 #include "minicsv.h"
 #include "LoadDataAPI.h"
 #include "EnableWarnings.h"
+
+#include <RcppEigenStubs.cpp>
 
 void pda(const double *ar, int rows, int cols);
 

--- a/src/ComputeGD.cpp
+++ b/src/ComputeGD.cpp
@@ -29,7 +29,7 @@
 #include <Eigen/Core>
 #include <Eigen/Cholesky>
 #include <Eigen/Dense>
-#include <Eigen/CholmodSupport>
+#include <RcppEigenCholmod.h>
 #include <RcppEigenWrap.h>
 #include "asa.h"
 

--- a/src/MarkovExpectation.cpp
+++ b/src/MarkovExpectation.cpp
@@ -16,7 +16,7 @@
 
 #include "omxExpectation.h"
 #include <Eigen/SparseCore>
-#include <Eigen/CholmodSupport>
+#include <RcppEigenCholmod.h>
 #include <RcppEigenWrap.h>
 #include "EnableWarnings.h"
 

--- a/src/RAMInternal.h
+++ b/src/RAMInternal.h
@@ -6,11 +6,9 @@
 #include <Eigen/SparseLU>
 #include <Eigen/Cholesky>
 //#include <Eigen/SparseCholesky>
-#include <Eigen/CholmodSupport>
-//#include <RcppEigenStubs.h>
-#include <RcppEigenWrap.h>
 //#include <Eigen/UmfPackSupport>
-//#include <RcppEigenCholmod.h>
+#include <RcppEigenCholmod.h>
+#include <RcppEigenWrap.h>
 #include "path.h"
 #include "Connectedness.h"
 

--- a/src/omxData.cpp
+++ b/src/omxData.cpp
@@ -34,7 +34,7 @@
 #include "nr.h"
 #include "omxBVN.h"
 #include "omxNLopt.h"
-#include <Eigen/CholmodSupport>
+#include <RcppEigenCholmod.h>
 #include <RcppEigenWrap.h>
 #include "CovEntrywisePar.h"
 #include "Compute.h"

--- a/src/omxExpectation.cpp
+++ b/src/omxExpectation.cpp
@@ -33,7 +33,7 @@
 #include "omxExpectation.h"
 #include "glue.h"
 #include "Compute.h"
-#include <Eigen/CholmodSupport>
+#include <RcppEigenCholmod.h>
 #include <RcppEigenWrap.h>
 #include "EnableWarnings.h"
 


### PR DESCRIPTION
A forthcoming version of **RcppEigen** will make CHOLMOD support optional, breaking packages linking **RcppEigen** _and_ requiring CHOLMOD support.  There are only two such packages: **lme4** and **OpenMx**.  Details are provided in RcppCore/RcppEigen#131, which stemmed from lme4/lme4#745.

**lme4** has already merged a PR making the necessary adjustments; see lme4/lme4#746.  The changes in this PR are very much parallel.  Applying the changes to the **OpenMx** sources available on CRAN and checking the resulting tarball under a patched build of **RcppEigen** reveals no problems.

Updated versions of **RcppEigen**, **lme4**, and **OpenMx** will need to be submitted together, requiring some co-ordination from @eddelbuettel, @bbolker, and you.  Let me know if these changes look OK or if I've missed something - I struggled for some number of minutes to understand how to build a tarball from a patched clone of the repo, then gave up ...