### PR TITLE
Allow users to specify an evaluation environment for `eval`

### DIFF
--- a/R/MxEval.R
+++ b/R/MxEval.R
@@ -14,7 +14,7 @@
 #   limitations under the License.
 
 mxGetEvalEnv <- function() {
-  mxOption(NULL, "evalEnv") %||% globalenv()
+	mxOption(NULL, "evalEnv")
 }
 
 mxEval <- function(expression, model, compute = FALSE, show = FALSE, defvar.row = 1L,

--- a/R/MxEval.R
+++ b/R/MxEval.R
@@ -13,6 +13,10 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+mxGetEvalEnv <- function() {
+  mxOption(NULL, "evalEnv") %||% globalenv()
+}
+
 mxEval <- function(expression, model, compute = FALSE, show = FALSE, defvar.row = 1L,
 			cache = new.env(parent = emptyenv()), cacheBack = FALSE, .extraBack=0L) {
 	if (missing(expression)) {
@@ -347,14 +351,14 @@ evaluateMxObject <- function(objname, flatModel, labelsData, cache) {
 		# mxFitFunctionRow genericFitAddEntities still needs this
 	}
 	return(eval(substitute(evaluateSymbol(x, objname, flatModel,
-			labelsData, globalenv(), compute = TRUE,
+			labelsData, mxGetEvalEnv(), compute = TRUE,
 			show = FALSE, outsideAlgebra = FALSE, defvar.row = 1,
 			cache = cache),
 			list(x = quote(as.symbol(objname))))))
 }
 
 evaluateAlgebraWithContext <- function(algebra, context, flatModel, labelsData, cache) {
-	return(evaluateExpression(algebra@formula, context, flatModel, labelsData, globalenv(),
+	return(evaluateExpression(algebra@formula, context, flatModel, labelsData, mxGetEvalEnv(),
 		compute = TRUE, show = FALSE, outsideAlgebra = FALSE, cache = cache))
 }
 

--- a/R/MxOptions.R
+++ b/R/MxOptions.R
@@ -39,7 +39,7 @@ mxOption <- function(model=NULL, key=NULL, value, reset = FALSE) {
 		}
 		return(processDefaultOptionList(key, value))
 	}
-	if (length(value) > 1 && key!="No Sort Data" && key != "Status OK") {
+	if (length(value) > 1 && key!="No Sort Data" && key != "Status OK" && key != "evalEnv") {
 		msg <- paste("argument 'value' must be either NULL or of length 1.",
 			"You gave me an object of length", length(value))
 		stop(msg)
@@ -179,7 +179,8 @@ otherOptions <- list(
     "Nudge zero starts" = "Yes",
     "Status OK"= as.statusCode(c("OK", "OK/green")),
     "Max minutes"=0,
-	"Analytic RAM derivatives" = "No"
+    "Analytic RAM derivatives" = "No",
+    "evalEnv" = globalenv()
 )
 
 limitMajorIterations <- function(options, numParam, numConstraints) {

--- a/R/MxOptions.R
+++ b/R/MxOptions.R
@@ -44,6 +44,9 @@ mxOption <- function(model=NULL, key=NULL, value, reset = FALSE) {
 			"You gave me an object of length", length(value))
 		stop(msg)
 	}
+	if (key == "evalEnv" && !is.environment(value)) {
+		stop("argument 'value' must be an environment.")
+	}
 	if (length(reset) != 1 || !is.logical(reset)) {
 		stop("argument 'reset' must be TRUE or FALSE")
 	}

--- a/man/mxOption.Rd
+++ b/man/mxOption.Rd
@@ -124,6 +124,7 @@ Nudge zero starts \tab [TRUE | FALSE] \tab Should OpenMx
 Status OK \tab character vector \tab Status codes that are considered to indicate a successful optimization \cr
 Max minutes \tab numeric \tab Maximum backend elapsed time, in minutes \cr
 Analytic RAM derivatives \tab [Yes | No] \tab Should the \link[=mxFitFunctionML]{ML fitfunction} compute analytic first and second derivatives for \link[=mxExpectationRAM]{RAM} models?  Note that mxOption "Analytic Gradients" must also be set to "Yes" for these derivatives to be used.  These derivatives are currently only implemented in the case of all-continuous variables, MxData of \code{type="cov"} or \code{type="raw"}, and absence of the following: definition variables, multilevel data, product nodes, Fellner fitfunction, \link[=mxAlgebra]{MxAlgebras} on \link[=mxPath]{paths}, and \link[=mxPenalty]{penalties}.
+evalEnv \tab [environment] \tab Where OpenMx expressions should be evaluated. Defaults to the global environment which is fine for interactive use. R packages that use OpenMx may adjust this option to ensure their code works without explicitly calling \code{library(OpenMx)}.
 }
 
 


### PR DESCRIPTION
Fixes https://github.com/OpenMx/OpenMx/issues/411

Comments, suggestions, and other feedback are welcome!

Intended usage in metasem (and other packages) can be seen [here](https://github.com/vandenman/metasem/compare/master...vandenman:metasem:OpenMxFix?expand=1)

which resolves the example in https://github.com/OpenMx/OpenMx/issues/411