### PR TITLE
Fix parent fit handling, constraint dup, isClone

### DIFF
--- a/src/omxFIMLFitFunction.cpp
+++ b/src/omxFIMLFitFunction.cpp
@@ -1222,12 +1222,15 @@ void omxFIMLFitFunction::compute2(int want, FitContext *fc)
 		} else {
 			omxMatrix *pfitMat = fc->getParentState()->getMatrixFromIndex(off->matrix);
 			auto *pff = (omxFIMLFitFunction*) pfitMat->fitFunction;
-			if (!pff->openmpUser) OOPS;
-			parent = pff;
-			ofiml->sufficientSets = pff->sufficientSets;
-			ofiml->useSufficientSets = pff->useSufficientSets;
-			elapsed.resize(ELAPSED_HISTORY_SIZE);
-			curElapsed = NA_INTEGER;
+			if (pff->openmpUser) {
+				parent = pff;
+				ofiml->sufficientSets = pff->sufficientSets;
+				ofiml->useSufficientSets = pff->useSufficientSets;
+				elapsed.resize(ELAPSED_HISTORY_SIZE);
+				curElapsed = NA_INTEGER;
+			} else {
+				if (!indexVector.size()) sortData(off);
+			}
 		}
 		builtCache = true;
 	}

--- a/src/omxState.cpp
+++ b/src/omxState.cpp
@@ -1038,8 +1038,12 @@ omxConstraint *UserConstraint::duplicate(omxState *dest) const
 	uc->opCode = opCode;
   uc->redundant = redundant;
   uc->size = size;
+  uc->origSize = origSize;
+  uc->strict = strict;
+  uc->seenActive = seenActive;
+  uc->initialJac = initialJac;
 	uc->pad = omxNewAlgebraFromOperatorAndArgs(10, args, 2, dest); // 10 = binary subtract
-	uc->jacobian = jacobian;
+	uc->jacobian = dest->lookupDuplicate(jacobian);
   uc->jacMap = jacMap;
   uc->verbose = verbose;
 	return uc;

--- a/src/omxState.h
+++ b/src/omxState.h
@@ -373,7 +373,7 @@ class omxState {
 	int getWantStage() const { return wantStage; }
 	void setWantStage(int stage);
 	int getId() const { return stateId; }
-	bool isClone() const { return workBoss != 0; } // rename to isWorkBoss TODO
+	bool isClone() const { return parent != 0; }
   bool isTopState() const { return parent == 0; }
 
 	std::vector< omxMatrix* > matrixList;


### PR DESCRIPTION
Fix parent fit handling, constraint dup, isClone
omxFIMLFitFunction: avoid unconditional OOPS by checking parent fit's openmpUser flag; if parent uses OpenMP copy parent pointers and sufficient-set flags, otherwise prepare local data by sorting (sortData) when needed.

omxState: UserConstraint::duplicate now preserves additional fields (origSize, strict, seenActive, initialJac) and uses dest->lookupDuplicate for the jacobian to ensure duplicated references point into the destination state rather than being shallow-copied.

omxState.h: isClone() now checks parent != 0 instead of workBoss != 0 to more accurately reflect clone/top-state status.

These changes fix crashes and ensure proper state/constraint duplication and correct clone detection.